### PR TITLE
ci: add step with Pythonic cruft cleanup

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -26,16 +26,18 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install '.[dev]'
+          find . -regex '^.*\(__pycache__\|\.py[co]\)$$' -delete;
+          find . -type d -name __pycache__ -exec rm -r {} \+
+          find . -type d -name '*.egg-info' -exec rm -rf {} +
+          find . -type d -name .mypy_cache -exec rm -r {} \+
+          rm -rf .pytest_cache;
+          rm -rf tests/.pytest_cache;
+          rm -rf dist build
+          rm -f .coverage*
+
       - name: Cleanup Pythonic Cruft
         run: |
-            find . -regex '^.*\(__pycache__\|\.py[co]\)$$' -delete;
-            find . -type d -name __pycache__ -exec rm -r {} \+
-            find . -type d -name '*.egg-info' -exec rm -rf {} +
-            find . -type d -name .mypy_cache -exec rm -r {} \+
-            rm -rf .pytest_cache;
-            rm -rf tests/.pytest_cache;
-            rm -rf dist build
-            rm -f .coverage*
+
       - name: Python Code Quality and Lint
         # You may pin to the exact commit or the version.
         # uses: ricardochaves/python-lint@32032eca67291cd71f88d79e61bc4b904ee03265

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -26,12 +26,12 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install '.[dev]'
-          find . -regex '^.*\(__pycache__\|\.py[co]\)$$' -delete;
-          find . -type d -name __pycache__ -exec rm -r {} \+
-          find . -type d -name '*.egg-info' -exec rm -rf {} +
-          find . -type d -name .mypy_cache -exec rm -r {} \+
-          rm -rf .pytest_cache;
-          rm -rf tests/.pytest_cache;
+          find . -regex '^.*\(__pycache__\|\.py[co]\)$$' -delete
+          find . -type d -name __pycache__ -exec rm -r {}
+          find . -type d -name '*.egg-info' -exec rm -rf {}
+          find . -type d -name .mypy_cache -exec rm -r {}
+          rm -rf .pytest_cache
+          rm -rf tests/.pytest_cache
           rm -rf dist build
           rm -f .coverage*
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -28,9 +28,9 @@ jobs:
           python3 -m pip install '.[dev]'
           find . -regex '^.*\(__pycache__\|\.py[co]\)$$' -delete
 	      find . -type d -name __pycache__ -exec rm -r {}	      
-          find . -type d -name .mypy_cache -exec rm -r {} \+
-	      rm -rf .pytest_cache;
-	      rm -rf tests/.pytest_cache;
+          find . -type d -name .mypy_cache -exec rm -r {}
+	      rm -rf .pytest_cache
+	      rm -rf tests/.pytest_cache
 	      rm -rf dist build
 	      rm -f .coverage*
 	      echo Finished cleaning out pythonic cruft...

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Python Code Quality and Lint
         # You may pin to the exact commit or the version.
         # uses: ricardochaves/python-lint@32032eca67291cd71f88d79e61bc4b904ee03265
-        uses: ricardochaves/python-lint@v1.1.0
+        uses: ricardochaves/python-lint@v1.4.0
         with:
           # A list of all paths to test
           python-root-list: "src/orqviz tests/orqviz"

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -27,7 +27,7 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install '.[dev]'	      
           rm -rf .mypy_cache
-
+          rm -Rf build dist
       - name: Python Code Quality and Lint
         # You may pin to the exact commit or the version.
         # uses: ricardochaves/python-lint@32032eca67291cd71f88d79e61bc4b904ee03265

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -26,14 +26,15 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install '.[dev]'
-          find . -regex '^.*\(__pycache__\|\.py[co]\)$$' -delete
-          find . -type d -name __pycache__ -exec rm -r {}
-          find . -type d -name '*.egg-info' -exec rm -rf {}
-          find . -type d -name .mypy_cache -exec rm -r {}
-          rm -rf .pytest_cache
-          rm -rf tests/.pytest_cache
-          rm -rf dist build
-          rm -f .coverage*
+          find . -regex '^.*\(__pycache__\|\.py[co]\)$$' -delete;
+	      find . -type d -name __pycache__ -exec rm -r {} \+
+	      find . -type d -name '*.egg-info' -exec rm -rf {} +
+          find . -type d -name .mypy_cache -exec rm -r {} \+
+	      rm -rf .pytest_cache;
+	      rm -rf tests/.pytest_cache;
+	      rm -rf dist build
+	      rm -f .coverage*
+	      echo Finished cleaning out pythonic cruft...
 
       - name: Python Code Quality and Lint
         # You may pin to the exact commit or the version.

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -26,9 +26,8 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install '.[dev]'
-          find . -regex '^.*\(__pycache__\|\.py[co]\)$$' -delete;
-	      find . -type d -name __pycache__ -exec rm -r {} \+
-	      find . -type d -name '*.egg-info' -exec rm -rf {} +
+          find . -regex '^.*\(__pycache__\|\.py[co]\)$$' -delete
+	      find . -type d -name __pycache__ -exec rm -r {}	      
           find . -type d -name .mypy_cache -exec rm -r {} \+
 	      rm -rf .pytest_cache;
 	      rm -rf tests/.pytest_cache;

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -25,9 +25,13 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install '.[dev]'	      
+          python3 -m pip install '.[dev]'
+          ls -alh .
+          tree
           rm -rf .mypy_cache
           rm -Rf build dist
+          mypy --ignore-missing-imports --namespace-packages src/orqviz tests/orqviz
+
       - name: Python Code Quality and Lint
         # You may pin to the exact commit or the version.
         # uses: ricardochaves/python-lint@32032eca67291cd71f88d79e61bc4b904ee03265

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install '.[dev]'	      
-          find . -type d -name .mypy_cache -exec rm -r {}
+          rm -rf .mypy_cache
 
       - name: Python Code Quality and Lint
         # You may pin to the exact commit or the version.

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -26,14 +26,11 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install '.[dev]'
-          find . -regex '^.*\(__pycache__\|\.py[co]\)$$' -delete
 	      find . -type d -name __pycache__ -exec rm -r {}	      
           find . -type d -name .mypy_cache -exec rm -r {}
 	      rm -rf .pytest_cache
 	      rm -rf tests/.pytest_cache
-	      rm -rf dist build
-	      rm -f .coverage*
-	      echo Finished cleaning out pythonic cruft...
+
 
       - name: Python Code Quality and Lint
         # You may pin to the exact commit or the version.

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -25,12 +25,8 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install '.[dev]'
-	      find . -type d -name __pycache__ -exec rm -r {}	      
+          python3 -m pip install '.[dev]'	      
           find . -type d -name .mypy_cache -exec rm -r {}
-	      rm -rf .pytest_cache
-	      rm -rf tests/.pytest_cache
-
 
       - name: Python Code Quality and Lint
         # You may pin to the exact commit or the version.

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Python Code Quality and Lint
         # You may pin to the exact commit or the version.
         # uses: ricardochaves/python-lint@32032eca67291cd71f88d79e61bc4b904ee03265
-        uses: ricardochaves/python-lint@v1.4.0
+        uses: ricardochaves/python-lint@v1.1.0
         with:
           # A list of all paths to test
           python-root-list: "src/orqviz tests/orqviz"

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -35,9 +35,6 @@ jobs:
           rm -rf dist build
           rm -f .coverage*
 
-      - name: Cleanup Pythonic Cruft
-        run: |
-
       - name: Python Code Quality and Lint
         # You may pin to the exact commit or the version.
         # uses: ricardochaves/python-lint@32032eca67291cd71f88d79e61bc4b904ee03265

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -26,7 +26,16 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install '.[dev]'
-
+      - name: Cleanup Pythonic Cruft
+        run: |
+            find . -regex '^.*\(__pycache__\|\.py[co]\)$$' -delete;
+            find . -type d -name __pycache__ -exec rm -r {} \+
+            find . -type d -name '*.egg-info' -exec rm -rf {} +
+            find . -type d -name .mypy_cache -exec rm -r {} \+
+            rm -rf .pytest_cache;
+            rm -rf tests/.pytest_cache;
+            rm -rf dist build
+            rm -f .coverage*
       - name: Python Code Quality and Lint
         # You may pin to the exact commit or the version.
         # uses: ricardochaves/python-lint@32032eca67291cd71f88d79e61bc4b904ee03265

--- a/src/orqviz/aliases.py
+++ b/src/orqviz/aliases.py
@@ -16,7 +16,7 @@ GridOfParameterVectors = np.ndarray  # Grid of ND arrays
 Weights = np.ndarray  # 1D vector of floats from 0-1
 DirectionVector = np.ndarray  # ND array with same shape as ParameterVector
 LossFunction = Callable[
-    [ParameterVector], float
+    [ParametersVector], float
 ]  # Function that can be scanned with orqviz
 GradientFunction = Callable[
     [ParameterVector, DirectionVector], float

--- a/src/orqviz/aliases.py
+++ b/src/orqviz/aliases.py
@@ -16,7 +16,7 @@ GridOfParameterVectors = np.ndarray  # Grid of ND arrays
 Weights = np.ndarray  # 1D vector of floats from 0-1
 DirectionVector = np.ndarray  # ND array with same shape as ParameterVector
 LossFunction = Callable[
-    [ParametersVector], float
+    [ParameterVector], float
 ]  # Function that can be scanned with orqviz
 GradientFunction = Callable[
     [ParameterVector, DirectionVector], float


### PR DESCRIPTION
Apparently, issues that we had with mypy stem from Github Actions caching some (?) directories (thanks @alexjuda for pointing this out!). This PR adds a cleaning step (taken from [z-quantum-actions](https://github.com/zapatacomputing/z-quantum-actions/blob/main/Makefile)) that deletes potentially conflicting directories.

