### PR TITLE
fix: mypy issues related to implicit optionals

### DIFF
--- a/src/orqviz/fourier.py
+++ b/src/orqviz/fourier.py
@@ -93,8 +93,8 @@ def perform_2D_fourier_transform(
 
 def plot_2D_fourier_result(
     result: FourierResult,
-    max_freq_x: float = None,
-    max_freq_y: float = None,
+    max_freq_x: Optional[float] = None,
+    max_freq_y: Optional[float] = None,
     show_negative_frequencies: bool = False,
     fig: Optional[matplotlib.figure.Figure] = None,
     ax: Optional[matplotlib.axes.Axes] = None,

--- a/src/orqviz/gradients.py
+++ b/src/orqviz/gradients.py
@@ -8,7 +8,7 @@ from .aliases import DirectionVector, GradientFunction, LossFunction, ParameterV
 def calculate_full_gradient(
     params: ParameterVector,
     loss_function: LossFunction,
-    gradient_function: GradientFunction = None,
+    gradient_function: Optional[GradientFunction] = None,
     stochastic: bool = False,
     eps: float = 1e-3,
 ) -> ParameterVector:

--- a/src/orqviz/pca/scans.py
+++ b/src/orqviz/pca/scans.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Tuple, Union
+from typing import Callable, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -11,7 +11,7 @@ def perform_2D_pca_scan(
     pca_object: PCAobject,
     loss_function: LossFunction,
     n_steps_x: int = 20,
-    n_steps_y: int = None,
+    n_steps_y: Optional[int] = None,
     offset: Union[Tuple[float, float], float] = (-1.0, 1.0),
     verbose: bool = False,
 ) -> Scan2DResult:


### PR DESCRIPTION
This fixes mypy errors occurring when `make style` is invoked. Apparently, all errors seem to occur because the implicit optionals are now disallowed by mypy.