### PR TITLE
half Hessian diagonal instead of doubling diagonal in SPSAHessian

### DIFF
--- a/src/orqviz/hessians/hessians.py
+++ b/src/orqviz/hessians/hessians.py
@@ -95,6 +95,8 @@ def get_Hessian(
 
                 op = np.outer(dir1.flatten(), dir2.flatten())
                 outer_prod_matrix = op + op.T
+                # half diagonal entries
+                outer_prod_matrix[(np.arange(n_params), np.arange(n_params))] /= 2
 
                 hessian_result = (dir2_gradient - dir1_gradient) / eps
                 Hessian_Matr += hessian_result * outer_prod_matrix
@@ -153,8 +155,6 @@ def get_Hessian_SPSA_approx(
 
         op = np.outer(dir1.flatten(), dir2.flatten())
         outer_prod_matrix = (op + op.T) / 2
-        # mutliply diagonal by two
-        outer_prod_matrix += np.diag(np.diag(outer_prod_matrix))
 
         hessian_result = (dir2_gradient - dir1_gradient) / eps
         Hessian_Matr += hessian_result * outer_prod_matrix

--- a/tests/orqviz/hessians/hessians_test.py
+++ b/tests/orqviz/hessians/hessians_test.py
@@ -14,15 +14,17 @@ from orqviz.io import load_viz_object, save_viz_object
 
 
 def COST_FUNCTION(params):
-    return np.sum(np.sin(params)) + np.sum(params**2) + params[0]**2 * params[1]**2
+    return (
+        np.sum(np.sin(params)) + np.sum(params**2) + params[0] ** 2 * params[1] ** 2
+    )
 
 
 def ANALYTICAL_HESSIAN(params):
     hessian = np.diag(2 - np.sin(params))
-    hessian[0][0] += 2 * params[1]**2
-    hessian[1][1] += 2 * params[0]**2
-    hessian[0][1] = 4*params[0]*params[1]
-    hessian[1][0] = 4*params[0]*params[1]
+    hessian[0][0] += 2 * params[1] ** 2
+    hessian[1][1] += 2 * params[0] ** 2
+    hessian[0][1] = 4 * params[0] * params[1]
+    hessian[1][0] = 4 * params[0] * params[1]
     return hessian
 
 
@@ -80,9 +82,16 @@ def test_get_hessian_SPSA_approx_io(params):
         loaded_hessian.eigenvectors, hessian.eigenvectors
     )
 
-HESSIAN_TEST_PARAMS = [np.zeros(4), np.ones(5), np.arange(4, dtype=float), np.pi / 4 * np.arange(8)]
 
-@pytest.mark.parametrize("params",HESSIAN_TEST_PARAMS)
+HESSIAN_TEST_PARAMS = [
+    np.zeros(4),
+    np.ones(5),
+    np.arange(4, dtype=float),
+    np.pi / 4 * np.arange(8),
+]
+
+
+@pytest.mark.parametrize("params", HESSIAN_TEST_PARAMS)
 def test_get_hessian_gives_correct_values(params):
     eps = 1e-5
     target_matrix = ANALYTICAL_HESSIAN(params)
@@ -98,7 +107,8 @@ def test_get_hessian_gives_correct_values(params):
         hessian.eigenvalues, target_eigenvalues, precision
     )
 
-@pytest.mark.parametrize("params",HESSIAN_TEST_PARAMS)
+
+@pytest.mark.parametrize("params", HESSIAN_TEST_PARAMS)
 def test_get_hessian_spsa_gives_correct_values(params):
     eps = 1e-5
     target_matrix = ANALYTICAL_HESSIAN(params)
@@ -114,4 +124,3 @@ def test_get_hessian_spsa_gives_correct_values(params):
     np.testing.assert_array_almost_equal(
         hessian.eigenvalues, target_eigenvalues, precision
     )
-

--- a/tests/orqviz/hessians/hessians_test.py
+++ b/tests/orqviz/hessians/hessians_test.py
@@ -75,18 +75,26 @@ def test_get_hessian_SPSA_approx(params):
 def test_get_hessian_gives_correct_values():
     params = np.zeros(4)
     eps = 1e-5
-    target_matrix = 2*np.eye(4)
-    target_eigenvalues = 2*np.ones(4)
+    target_matrix = 2 * np.eye(4)
+    target_eigenvalues = 2 * np.ones(4)
 
     hessian_exact = get_Hessian(params, COST_FUNCTION, gradient_function=None, eps=eps)
     hessian_approx = get_Hessian_SPSA_approx(
         params, COST_FUNCTION, gradient_function=None, eps=eps, n_reps=10000
     )
     precision = int(np.abs(np.log10(eps)))
-    
-    np.testing.assert_array_almost_equal(hessian_exact.hessian_matrix, target_matrix, precision)
-    np.testing.assert_array_almost_equal(hessian_exact.eigenvalues, target_eigenvalues, precision)
 
-    np.testing.assert_array_almost_equal(hessian_approx.hessian_matrix, target_matrix, approx_precision)
-    np.testing.assert_array_almost_equal(hessian_approx.eigenvalues, target_eigenvalues, approx_precision)
+    np.testing.assert_array_almost_equal(
+        hessian_exact.hessian_matrix, target_matrix, precision
+    )
+    np.testing.assert_array_almost_equal(
+        hessian_exact.eigenvalues, target_eigenvalues, precision
+    )
 
+    approx_precision = 1
+    np.testing.assert_array_almost_equal(
+        hessian_approx.hessian_matrix, target_matrix, approx_precision
+    )
+    np.testing.assert_array_almost_equal(
+        hessian_approx.eigenvalues, target_eigenvalues, approx_precision
+    )

--- a/tests/orqviz/hessians/hessians_test.py
+++ b/tests/orqviz/hessians/hessians_test.py
@@ -44,9 +44,11 @@ def test_get_hessian(params):
     )
 
 
-def test_get_hessian_SPSA_approx():
-    params = np.random.rand(8)
-
+@pytest.mark.parametrize(
+    "params",
+    [np.random.rand(8)],
+)
+def test_get_hessian_SPSA_approx(params):
     hessian = get_Hessian_SPSA_approx(
         params, COST_FUNCTION, gradient_function=None, eps=1e-3, n_reps=20
     )
@@ -59,7 +61,6 @@ def test_get_hessian_SPSA_approx():
         == len(hessian.eigenvectors.T)
         == len(params)
     )
-
     save_viz_object(hessian, "test")
     loaded_hessian = load_viz_object("test")
     os.remove("test")
@@ -69,3 +70,23 @@ def test_get_hessian_SPSA_approx():
     np.testing.assert_array_almost_equal(
         loaded_hessian.eigenvectors, hessian.eigenvectors
     )
+
+
+def test_get_hessian_gives_correct_values():
+    params = np.zeros(4)
+    eps = 1e-5
+    target_matrix = 2*np.eye(4)
+    target_eigenvalues = 2*np.ones(4)
+
+    hessian_exact = get_Hessian(params, COST_FUNCTION, gradient_function=None, eps=eps)
+    hessian_approx = get_Hessian_SPSA_approx(
+        params, COST_FUNCTION, gradient_function=None, eps=eps, n_reps=10000
+    )
+    precision = int(np.abs(np.log10(eps)))
+    
+    np.testing.assert_array_almost_equal(hessian_exact.hessian_matrix, target_matrix, precision)
+    np.testing.assert_array_almost_equal(hessian_exact.eigenvalues, target_eigenvalues, precision)
+
+    np.testing.assert_array_almost_equal(hessian_approx.hessian_matrix, target_matrix, approx_precision)
+    np.testing.assert_array_almost_equal(hessian_approx.eigenvalues, target_eigenvalues, approx_precision)
+


### PR DESCRIPTION
Reworking a change from [this PR](https://github.com/zapatacomputing/orqviz/pull/53).
After comparing with automatic differentiation hessians, the SPSA hessian implementation was correct, but the full hessian implementation had a doubled diagonal. 