### PR TITLE
chore: Update minimum Python version

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.9", "3.10", "3.11"]
 
     name: Coverage - Python ${{ matrix.python }} - ${{ matrix.os }}
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -22,7 +22,7 @@ jobs:
     # Run jobs for a couple of Python versions.
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.9", "3.10", "3.11"]
 
     name: Style - Python ${{ matrix.python }}
 

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,3 @@
 # © Copyright 2022 Zapata Computing Inc.
 ################################################################################
 include subtrees/z_quantum_actions/Makefile
-
-github_actions:
-	${PYTHON_EXE} -m venv ${VENV_NAME}
-	"${VENV_NAME}/${VENV_BINDIR}/${PYTHON_EXE}" -m pip install --upgrade pip
-	"${VENV_NAME}/${VENV_BINDIR}/${PYTHON_EXE}" -m pip install git+https://github.com/zapatacomputing/orquestra-python-dev.git@chore/zqs-1372/jamesclark-zapata/python-311
-	"${VENV_NAME}/${VENV_BINDIR}/${PYTHON_EXE}" -m pip install -e '.[dev]'

--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,9 @@
 # © Copyright 2022 Zapata Computing Inc.
 ################################################################################
 include subtrees/z_quantum_actions/Makefile
+
+github_actions:
+	${PYTHON_EXE} -m venv ${VENV_NAME}
+	"${VENV_NAME}/${VENV_BINDIR}/${PYTHON_EXE}" -m pip install --upgrade pip
+	"${VENV_NAME}/${VENV_BINDIR}/${PYTHON_EXE}" -m pip install git+https://github.com/zapatacomputing/orquestra-python-dev.git@chore/zqs-1372/jamesclark-zapata/python-311
+	"${VENV_NAME}/${VENV_BINDIR}/${PYTHON_EXE}" -m pip install -e '.[dev]'

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,9 @@ author_email = info@zapatacomputing.com,
 license = Apache Software License 
 license_file = LICENSE
 classifiers =
-    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Operating System :: OS Independent
     License :: OSI Approved :: Apache Software License
     Topic :: Scientific/Engineering
@@ -18,7 +20,7 @@ classifiers =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.9
 
 install_requires =
     numpy>=1.14.6

--- a/src/orqviz/plot_utils.py
+++ b/src/orqviz/plot_utils.py
@@ -3,9 +3,9 @@ from typing import Optional, Tuple
 
 import matplotlib.pyplot as plt
 import matplotlib.ticker as tck
+import mpl_toolkits
 import numpy as np
 from matplotlib.cm import ScalarMappable
-import mpl_toolkits
 
 
 def normalize_color_and_colorbar(

--- a/src/orqviz/plot_utils.py
+++ b/src/orqviz/plot_utils.py
@@ -4,6 +4,7 @@ from typing import Optional, Tuple
 import matplotlib.pyplot as plt
 import matplotlib.ticker as tck
 import numpy as np
+from matplotlib.cm import ScalarMappable
 
 
 def normalize_color_and_colorbar(
@@ -40,9 +41,11 @@ def normalize_color_and_colorbar(
                 "Provided ax does not contain an image in ax.images or ax.collections"
             ) from e
 
-    image.colorbar.remove()
-    image.set_clim(vmin=min_val, vmax=max_val)
-    image.set_cmap(cmap)
+    assert isinstance(image, ScalarMappable)
+    if image.colorbar is not None:
+        image.colorbar.remove()
+    image.set_clim(vmin=min_val, vmax=max_val)  # type: ignore
+    image.set_cmap(cmap)  # type: ignore
     fig.colorbar(image, ax=ax)
 
 

--- a/src/orqviz/plot_utils.py
+++ b/src/orqviz/plot_utils.py
@@ -5,6 +5,7 @@ import matplotlib.pyplot as plt
 import matplotlib.ticker as tck
 import numpy as np
 from matplotlib.cm import ScalarMappable
+import mpl_toolkits
 
 
 def normalize_color_and_colorbar(
@@ -65,7 +66,6 @@ def get_colorbar_from_ax(
     _, ax = _check_and_create_fig_ax(ax=ax)
 
     if image_index is None:
-
         len_collections = len(ax.collections)
         len_images = len(ax.images)
 
@@ -158,7 +158,6 @@ def _check_and_create_fig_ax(
     fig: Optional[plt.Figure] = None,
     ax: Optional[plt.Axes] = None,
 ) -> Tuple[plt.Figure, plt.Axes]:
-
     if fig is None:
         fig = plt.gcf()
 
@@ -170,7 +169,7 @@ def _check_and_create_fig_ax(
 
 def _check_and_create_3D_ax(
     ax: Optional[plt.Axes] = None,
-) -> plt.Axes:
+) -> mpl_toolkits.mplot3d.Axes3D:
     if ax is None:
         fig = plt.figure()
         ax = fig.add_subplot(projection="3d")

--- a/src/orqviz/scans/plots.py
+++ b/src/orqviz/scans/plots.py
@@ -163,6 +163,8 @@ def plot_2D_scan_result_as_3D(
     """
     ax = _check_and_create_3D_ax(ax=ax)
 
+    assert ax is not None
+
     x, y = scan2D_result._get_coordinates_on_directions(
         in_units_of_direction=in_units_of_direction
     )

--- a/src/orqviz/scans/plots.py
+++ b/src/orqviz/scans/plots.py
@@ -3,9 +3,6 @@ from typing import Optional
 import matplotlib
 import numpy as np
 
-# this import is unused but solves issues with older matplotlib versions and 3d plots
-from mpl_toolkits.mplot3d import Axes3D
-
 from ..plot_utils import _check_and_create_3D_ax, _check_and_create_fig_ax
 from .data_structures import Scan1DResult, Scan2DResult
 
@@ -161,9 +158,9 @@ def plot_2D_scan_result_as_3D(
         plot_kwargs: kwargs for plotting with matplotlib.pyplot.plot_surface
             (plt.plot_surface)
     """
-    ax = _check_and_create_3D_ax(ax=ax)
+    ax3D = _check_and_create_3D_ax(ax=ax)
 
-    assert ax is not None
+    assert ax3D is not None
 
     x, y = scan2D_result._get_coordinates_on_directions(
         in_units_of_direction=in_units_of_direction
@@ -173,10 +170,10 @@ def plot_2D_scan_result_as_3D(
     plot_kwargs_defaults = {"cmap": "viridis", "alpha": 0.8}
     plot_kwargs = {**plot_kwargs_defaults, **plot_kwargs}
 
-    ax.plot_surface(XX, YY, scan2D_result.values, **plot_kwargs)
+    ax3D.plot_surface(XX, YY, scan2D_result.values, **plot_kwargs)
 
-    ax.view_init(elev=35, azim=-70)
+    ax3D.view_init(elev=35, azim=-70)
 
-    ax.set_xlabel("Scan Direction x")
-    ax.set_ylabel("Scan Direction y")
-    ax.set_zlabel("Loss Value")
+    ax3D.set_xlabel("Scan Direction x")
+    ax3D.set_ylabel("Scan Direction y")
+    ax3D.set_zlabel("Loss Value")


### PR DESCRIPTION
## Description

In order to allow Python versions newer than 3.10 we need to remove the upper bound.

This PR:
- allows orqviz to work on 3.11 and later
- fixes some new typing issues

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
